### PR TITLE
Guard against undefined std::string behavior.

### DIFF
--- a/src/c-int-source-funcs.inc
+++ b/src/c-int-source-funcs.inc
@@ -157,7 +157,7 @@ std::string GetMapValue(std::map<std::string,std::string> Map, int Item)
 		if (o) \
 		{ \
 			try { \
-				((MusicBrainz5::C##TYPE1 *)o)->Set##PROP1(str); \
+				((MusicBrainz5::C##TYPE1 *)o)->Set##PROP1(str ? str : ""); \
 			} \
 			catch (...) { \
 			} \


### PR DESCRIPTION
* Passing NULL char pointer to std::string constructor results
  in undefined behaviour, so guard against that in the generated
  C interface. See:

  http://stackoverflow.com/questions/17464514/initialize-stdstring-from-a-possibly-null-char-pointer

This came out of a discussion of a crash in sound-juicer on FreeBSD 11.0-CURRENT on the GNOME bugzilla: https://bugzilla.gnome.org/show_bug.cgi?id=742019 The current code happens to work on Linux, but this is a coincidence, and not based on defined behaviour, AFAICT.

I think it is fair that libmusicbrainz should guard against this so the C interface can be idiomatic, but libmusicbrainz avoids the undefined behaviour internally.

Thoughts?