### PR TITLE
Fix local includes in Query.h

### DIFF
--- a/include/musicbrainz5/Query.h
+++ b/include/musicbrainz5/Query.h
@@ -26,9 +26,9 @@
 #ifndef _MUSICBRAINZ5_QUERY_H
 #define _MUSICBRAINZ5_QUERY_H
 
-#include "defines.h"
+#include "musicbrainz5/defines.h"
 
-#include "Entity.h"
+#include "musicbrainz5/Entity.h"
 
 #include "musicbrainz5/ReleaseList.h"
 #include "musicbrainz5/Metadata.h"


### PR DESCRIPTION
This is inconsistent with all other includes and creates problems when
using the -I- flag on old versions of gcc.

This came up when using this library on [Haiku OS](https://www.haiku-os.org/).