### PR TITLE
src/CMakelists.txt: do not use wildcards for dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,8 @@ ADD_CUSTOM_COMMAND(
 	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mb5_c.cc ${CMAKE_CURRENT_BINARY_DIR}/mb5_c.h ${CMAKE_CURRENT_BINARY_DIR}/../include/musicbrainz5/mb5_c.h
 	COMMAND make-c-interface ${CMAKE_CURRENT_SOURCE_DIR} cinterface.xml ${CMAKE_CURRENT_BINARY_DIR} mb5_c.cc mb5_c.h
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different 	${CMAKE_CURRENT_BINARY_DIR}/mb5_c.h ${CMAKE_CURRENT_BINARY_DIR}/../include/musicbrainz5/mb5_c.h
-	DEPENDS make-c-interface cinterface.xml *.inc
+	DEPENDS make-c-interface cinterface.xml c-int-medium-defines.inc c-int-query-source.inc c-int-source-funcs.inc
+                c-int-medium-source.inc c-int-release-defines.inc c-int-query-defines.inc c-int-release-source.inc
 )
 
 ADD_CUSTOM_TARGET(src_gen DEPENDS mb5_c.h)


### PR DESCRIPTION
This is discouraged by cmake's documentation and doesn't work with the ninja generator.