### PR TITLE
libxml: Fix include error and fix const error

### DIFF
--- a/src/xmlParser.cc
+++ b/src/xmlParser.cc
@@ -57,7 +57,7 @@ XMLNode *XMLRootNode::parseFile(const std::string &filename, XMLResults* results
 
     doc = xmlParseFile(filename.c_str());
     if ((doc == NULL) && (results != NULL)) {
-        xmlErrorPtr error = xmlGetLastError();
+        const xmlError *error = xmlGetLastError();
         results->message = error->message;
         results->line = error->line;
         results->code = error->code;
@@ -72,7 +72,7 @@ XMLNode *XMLRootNode::parseString(const std::string &xml, XMLResults* results)
 
     doc = xmlParseMemory(xml.c_str(), xml.length());
     if ((doc == NULL) && (results != NULL)) {
-        xmlErrorPtr error = xmlGetLastError();
+        const xmlError *error = xmlGetLastError();
         results->message = error->message;
         results->line = error->line;
         results->code = error->code;

--- a/src/xmlParser.cc
+++ b/src/xmlParser.cc
@@ -30,6 +30,7 @@
 
 #include <cstring>
 #include <libxml/tree.h>
+#include <libxml/parser.h>
 
 XMLResults::XMLResults()
     : line(0),


### PR DESCRIPTION
Stems from errors such as:
```c++
src/xmlParser.cc: In static member function 'static XMLNode* XMLRootNode::parseFile(const std::string&, XMLResults*)':
src/xmlParser.cc:57:11: error: 'xmlParseFile' was not declared in this scope; did you mean 'xmlSaveFile'?
   57 |     doc = xmlParseFile(filename.c_str());
      |           ^~~~~~~~~~~~
      |           xmlSaveFile
src/xmlParser.cc:59:9: error: 'xmlErrorPtr' was not declared in this scope; did you mean 'xmlDocPtr'?
   59 |         xmlErrorPtr error = xmlGetLastError();
      |         ^~~~~~~~~~~
      |         xmlDocPtr
src/xmlParser.cc:60:28: error: 'error' was not declared in this scope; did you mean 'perror'?
   60 |         results->message = error->message;
      |                            ^~~~~
      |                            perror
src/xmlParser.cc: In static member function 'static XMLNode* XMLRootNode::parseString(const std::string&, XMLResults*)':
src/xmlParser.cc:72:11: error: 'xmlParseMemory' was not declared in this scope
   72 |     doc = xmlParseMemory(xml.c_str(), xml.length());
      |           ^~~~~~~~~~~~~~
src/xmlParser.cc:74:9: error: 'xmlErrorPtr' was not declared in this scope; did you mean 'xmlDocPtr'?
   74 |         xmlErrorPtr error = xmlGetLastError();
      |         ^~~~~~~~~~~
      |         xmlDocPtr
src/xmlParser.cc:75:28: error: 'error' was not declared in this scope; did you mean 'perror'?
   75 |         results->message = error->message;
      |                            ^~~~~
      |                            perror
```